### PR TITLE
Bug fix (LP problem scaling in GLPK)

### DIFF
--- a/R/LPproblem_glpkClass.R
+++ b/R/LPproblem_glpkClass.R
@@ -300,7 +300,7 @@ setMethod("solveLp", signature(lp = "LPproblem_glpk"),
                      out <- solveInterior(lp@ptr)
                    },
                    "exact" = {
-                     invisible(scaleSimplexProb(lp@ptr))
+                     scaleSimplexProb(lp@ptr)
                      out <- solveSimplexExact(lp@ptr)
                    },
                    "mip" = {

--- a/src/GLPK.cpp
+++ b/src/GLPK.cpp
@@ -322,8 +322,6 @@ SEXP solveSimplex(SEXP xp) {
 
   glp_prob* lp = (glp_prob*)R_ExternalPtrAddr(xp);
 
-  // glp_scale_prob(lp, GLP_SF_AUTO);
-
   int ret = 0;
 
   ret = glp_simplex(lp, &parmS);
@@ -362,7 +360,7 @@ SEXP scaleSimplexProb(SEXP xp) {
   glp_prob* lp = (glp_prob*)R_ExternalPtrAddr(xp);
 
   glp_term_hook(hook, NULL); // redirects output to somewhere NULL
-  glp_scale_prob(lp, GLP_SF_AUTO);
+  glp_scale_prob(lp, GLP_SF_SKIP);
   glp_term_hook(NULL, NULL); // get output back to console
 
   return out;


### PR DESCRIPTION
In rare cases, glpk entered an infinite loop with the warning message

    Warning: numerical instability (primal simplex, phase II)

The bug is fixed when triggering contraint matrix scaling with the flag "GLP_SF_SKIP" instead of "GLP_SF_AUTO".

"GLP_SF_SKIP" skips matrix scaling, if the the problem is already well scaled.

(related to https://github.com/jotech/gapseq/issues/266)